### PR TITLE
Configure the pages/modules with a quiz (untried)

### DIFF
--- a/resources/extensions/module_info_tree_processor.rb
+++ b/resources/extensions/module_info_tree_processor.rb
@@ -11,13 +11,14 @@ class ModuleInfoTreeProcessor < Extensions::TreeProcessor; use_dsl
         require 'yaml'
         module_descriptor = YAML::load_file(path)
         document_slug = (document.attr 'slug')
-        module_descriptor['nav'].each_with_index do |item, index|
-          document.set_attribute "module-toc-link-#{index}", item['url']
-          document.set_attribute "module-toc-title-#{index}", item['title']
-          document.set_attribute "module-toc-slug-#{index}", item['slug']
-          if item.has_key?('next') && (document_slug == item['slug'])
-            document.set_attr "module-next-slug", item['next']['slug'], false
-            document.set_attr "module-next-title", item['next']['title'], false
+        module_descriptor['pages'].each_with_index do |page, index|
+          document.set_attribute "module-toc-link-#{index}", page['url']
+          document.set_attribute "module-toc-title-#{index}", page['title']
+          document.set_attribute "module-toc-slug-#{index}", page['slug']
+          document.set_attribute "module-quiz-#{index}", page['quiz']
+          if page.has_key?('next') && (document_slug == page['slug'])
+            document.set_attr "module-next-slug", page['next']['slug'], false
+            document.set_attr "module-next-title", page['next']['title'], false
           end
         end
         document.set_attribute "module-name", module_descriptor['module_name']

--- a/resources/templates/course/document.html.erb
+++ b/resources/templates/course/document.html.erb
@@ -1,3 +1,6 @@
+<%
+require 'json'
+%>
 <article id="content" role="main">
   <div class="content-wrapper">
     <div class="dev-menu-nav large-2 hide-for-medium-only hide-for-small-only columns">
@@ -51,8 +54,20 @@
         <div class="paragraph">
           <a data-type="grade-quiz" data-slug="<%= attr('slug') %>" class="next-section medium button" href="../<%= attr('module-next-slug') %>/">Continue to <%= attr('module-next-title') %></a>
         </div>
+        <%
+          modules = (@attributes.select { |k, _| k.start_with?('module-quiz-') }.keys.map do |quiz_attr|
+            quiz_index = quiz_attr.sub('module-quiz-', '')
+            page_slug_attr = "module-toc-slug-#{quiz_index}"
+            if attr(quiz_attr) == 'true'
+              attr(page_slug_attr)
+            else
+              nil
+            end
+          end).compact
+        %>
         <script>
           window.trainingClassName = "<%= attr('module-name') %>"
+          window.trainingClassModules = <%= modules.to_json %>
         </script>
         <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
         <script src="https://neo4jsandbox.com/js/js.cookie-2.1.3.min.js"></script>


### PR DESCRIPTION
If an AsciiDoc document has a section with a role "quiz" then this page/module will be flagged as "untried".

I'm using the `ModuleInfoTreeProcessor` to set a list of indexed attributes on each document:

```adoc
:module-toc-slug-0: introduction-to-neo4j-4-0
:module-quiz-0: false

:module-toc-slug-1: neo4j-graph-database
:module-quiz-1: true

:module-toc-slug-2: neo4j-graph-platform
:module-quiz-1: true

// ...
```

With the above data, I know that there's a quiz on page `neo4j-graph-database` and `neo4j-graph-platform` but not on page `introduction-to-neo4j-4-0`.

My initial list of untried pages/modules will be: `['neo4j-graph-database', 'neo4j-graph-platform']`. This list will be updated once the actual quiz status has been fetched from the backend.

In the example below, the two modules are actually "passed":

![load](https://user-images.githubusercontent.com/333276/76091510-ff01ff00-5fbd-11ea-9577-3ffa99de5ba1.gif)
