### PR TITLE
resolves #73 automatically add '_testing_' prefix when publishing pages in "testing"

### DIFF
--- a/buildSrc/src/main/kotlin/com/neo4j/gradle/asciidoctor/AsciidoctorModuleDescriptorPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/neo4j/gradle/asciidoctor/AsciidoctorModuleDescriptorPlugin.kt
@@ -24,6 +24,9 @@ open class AsciidoctorModuleDescriptorPlugin : Plugin<Project> {
 }
 
 abstract class AsciidoctorModuleDescriptorGenerateTask : DefaultTask() {
+
+  private val TESTING_SLUG_PREFIX = "_testing_"
+
   @InputFiles
   var sources: MutableList<ConfigurableFileTree> = mutableListOf()
 
@@ -55,10 +58,16 @@ abstract class AsciidoctorModuleDescriptorGenerateTask : DefaultTask() {
       val document = asciidoctor.loadFile(file, emptyMap())
       val url = "${file.name.removeSuffix(".adoc")}.html"
       val title = document.doctitle
-      val slug = document.getAttribute("slug", "") as String
+      val slugAttrValue = document.getAttribute("slug", "") as String
       val hasQuiz = document.findBy(mapOf("context" to ":section", "role" to "quiz")).isNotEmpty()
       val hasCertificate = document.findBy(mapOf("context" to ":section", "role" to "certificate")).isNotEmpty()
-      if (slug.isNotBlank()) {
+      if (slugAttrValue.isNotBlank()) {
+        val stage = document.getAttribute("stage", "") as String
+        val slug = if (stage == "production") {
+          slugAttrValue
+        } else {
+          "$TESTING_SLUG_PREFIX${slugAttrValue}"
+        }
         mapOf(
           "title" to title,
           "url" to url,

--- a/resources/extensions/module_info_tree_processor.rb
+++ b/resources/extensions/module_info_tree_processor.rb
@@ -4,28 +4,38 @@ require 'pathname'
 include Asciidoctor
 
 class ModuleInfoTreeProcessor < Extensions::TreeProcessor; use_dsl
+
+  TESTING_SLUG_PREFIX = '_testing_'
+
   def process(document)
     if (docdir = document.attr 'docdir')
       path = File.expand_path('../build/online/asciidoctor-module-descriptor.yml', docdir)
       if File.exist?(path)
         require 'yaml'
         module_descriptor = YAML::load_file(path)
-        document_slug = (document.attr 'slug')
+        document_slug = if (document.attr 'stage') != 'production' && (slug = document.attr 'slug')
+          slug = "#{TESTING_SLUG_PREFIX}#{slug}"
+          document.set_attr 'slug', slug
+          slug
+        else
+          (document.attr 'slug')
+        end
         module_descriptor['pages'].each_with_index do |page, index|
           document.set_attribute "module-toc-link-#{index}", page['url']
           document.set_attribute "module-toc-title-#{index}", page['title']
-          document.set_attribute "module-toc-slug-#{index}", page['slug']
+          page_slug = page['slug']
+          document.set_attribute "module-toc-slug-#{index}", page_slug
           document.set_attribute "module-quiz-#{index}", page['quiz']
-          if document_slug == page['slug']
+          if document_slug == page_slug
             if page.has_key?('next')
-              document.set_attr "module-next-slug", page['next']['slug'], false
-              document.set_attr "module-next-title", page['next']['title'], false
+              document.set_attr 'module-next-slug', page['next']['slug'], false
+              document.set_attr 'module-next-title', page['next']['title'], false
             end
-            document.set_attribute "module-quiz", page['quiz']
-            document.set_attribute "module-certificate", page['certificate']
+            document.set_attribute 'module-quiz', page['quiz']
+            document.set_attribute 'module-certificate', page['certificate']
           end
         end
-        document.set_attribute "module-name", module_descriptor['module_name']
+        document.set_attribute 'module-name', module_descriptor['module_name']
       end
     end
     document


### PR DESCRIPTION
We are actually using the `_testing_` when the stage is *not* "production". I think it's the safest option so if you don't explicitly set "-Pstage=production" it will use the `_testing_` prefix.

Please note that we will also use this prefix when the stage is "local".

The idea is to prevent mistake like:

```
$ ./gradlew 4.0-intro-neo4j:wordPressUploadCourse -Pstage=test
```

Since stage test does not exists, we will actually use the "unmodified" slug and overwrite production page.

@ElaineRosenberg Let me know if that sounds good.

resolves #73