### PR TITLE
Fixes for the Intro to Neo4j 4 material

### DIFF
--- a/modules/4.0-intro-neo4j/docs/05_WorkingWithPatternsInQueries.adoc
+++ b/modules/4.0-intro-neo4j/docs/05_WorkingWithPatternsInQueries.adoc
@@ -60,7 +60,7 @@ In all, six relationships were traversed.
 image::TheReplacementsTraversal.png[TheReplacementsTraversal,width=500,align=center]
 --
 
-== Specifying multiple `MATCH` patterns
+== Specifying multiple patterns in a `MATCH`
 
 [.notes]
 --
@@ -128,7 +128,7 @@ This is useful when you are looking for a specific node in the graph and want to
 You will learn about creating nodes and relationships later in this training. 
 --
 
-=== Example: Using two MATCH patterns
+=== Example: Using two patterns in a `MATCH`
 
 [.notes]
 --
@@ -173,7 +173,7 @@ endif::[]
 image::KeanuFriendsForHugo.png[KeanuFriendsForHugo,width=500,align=center]
 --
 
-=== Example: Two `MATCH` patterns required
+=== Example: Two patterns in a `MATCH` required
 
 [.notes]
 --
@@ -426,7 +426,7 @@ For example, here is an example where we want a subgraph of all nodes connected 
 
 [source,cypher]
 ----
-MATCH paths = ((m:Movie)-[rel]-(p:Person))
+MATCH paths = (m:Movie)-[rel]-(p:Person)
 WHERE m.title = 'The Replacements'
 RETURN paths
 ----

--- a/modules/4.0-intro-neo4j/docs/07_ControllingTheQueryChain.adoc
+++ b/modules/4.0-intro-neo4j/docs/07_ControllingTheQueryChain.adoc
@@ -159,7 +159,7 @@ Here is another example where we want to find all actors who have acted in at le
 [source,cypher]
 ----
 MATCH (p:Person)
-WITH p, size((p)-[:ACTED_IN]->(:Movie)) AS movies
+WITH p, size((p)-[:ACTED_IN]->()) AS movies
 WHERE movies >= 5
 OPTIONAL MATCH (p)-[:DIRECTED]->(m:Movie)
 RETURN p.name, m.title

--- a/modules/4.0-intro-neo4j/docs/08_ControllingResultsReturned.adoc
+++ b/modules/4.0-intro-neo4j/docs/08_ControllingResultsReturned.adoc
@@ -154,7 +154,7 @@ In this example, we specify that the release date of the movies for _Tom Hanks_ 
 [source,cypher]
 ----
 MATCH (p:Person)-[:DIRECTED | ACTED_IN]->(m:Movie)
-WHERE p.name = 'Tom Hanks'OR p.name = 'Keanu Reeves'
+WHERE p.name = 'Tom Hanks' OR p.name = 'Keanu Reeves'
 RETURN DISTINCT m.title, m.released ORDER BY m.released DESC
 ----
 
@@ -178,7 +178,7 @@ Here we want the rows to be sorted by the release date, descending, and then by 
 [source,cypher]
 ----
 MATCH (p:Person)-[:DIRECTED | ACTED_IN]->(m:Movie)
-WHERE p.name = 'Tom Hanks'OR p.name = 'Keanu Reeves'
+WHERE p.name = 'Tom Hanks' OR p.name = 'Keanu Reeves'
 RETURN DISTINCT m.title, m.released ORDER BY m.released DESC , m.title
 ----
 
@@ -339,7 +339,7 @@ How can you change this code so that a movie title will only be returned once?
 
 [source,cypher]
 ----
-MATCH ()-[:REVIEWED]->(m:Movie)
+MATCH (m:Movie)<-[:REVIEWED]-()
 RETURN  m.title
 ----
 
@@ -347,14 +347,14 @@ RETURN  m.title
 Select the correct answers.
 
 [%interactive.answers]
-- [x] `MATCH ()-[:REVIEWED]->(m:Movie)`
+- [x] `MATCH (m:Movie)<-[:REVIEWED]-()`
        `RETURN  DISTINCT m.title`
-- [ ] `MATCH ()-[:REVIEWED]->(m:Movie)`
+- [ ] `MATCH (m:Movie)<-[:REVIEWED]-()`
        `RETURN  UNIQUE m.title`
-- [x] `MATCH ()-[:REVIEWED]->(m:Movie)`
+- [x] `MATCH (m:Movie)<-[:REVIEWED]-()`
       `WITH DISTINCT m`
        `RETURN  m.title`
-- [ ] `MATCH ()-[:REVIEWED]->(m:Movie)`
+- [ ] `MATCH (m:Movie)<-[:REVIEWED]-()`
        `WITH UNIQUE m`
        `RETURN  m.title`
 
@@ -375,7 +375,7 @@ Select the correct answer.
 === Question 3
 
 [.statement]
-We want to retrieve the names of the five oldest actors in our dataset. What code will do this?
+We want to retrieve the names of the five oldest persons in our dataset. What code will do this?
 
 [.statement]
 Select the correct answers.
@@ -384,13 +384,13 @@ Select the correct answers.
 - [ ] `MATCH (p:Person)-[:ACTED_IN]->()`
       `WITH p LIMIT 5`
       `RETURN DISTINCT p.name, p.born ORDER BY p.born`
-- [x] `MATCH (p:Person)`
+- [ ] `MATCH (p:Person)`
       `WITH p LIMIT 5`
       `RETURN DISTINCT p.name, p.born ORDER BY p.born`
-- [x] `MATCH (p:Person)-[:ACTED_IN]->()`
+- [ ] `MATCH (p:Person)-[:ACTED_IN]->()`
       `RETURN DISTINCT p.name, p.born ORDER BY p.born LIMIT 5`
 - [x] `MATCH (p:Person)`
-      `ETURN DISTINCT p.name, p.born ORDER BY p.born LIMIT 5`
+      `RETURN DISTINCT p.name, p.born ORDER BY p.born LIMIT 5`
 
 [.summary]
 == Summary

--- a/modules/4.0-intro-neo4j/docs/10_CreatingRelationships.adoc
+++ b/modules/4.0-intro-neo4j/docs/10_CreatingRelationships.adoc
@@ -376,9 +376,9 @@ Assuming the nodes are successfully retrieved, how many relationships are create
 ----
 MATCH (a:Person), (m:Movie)
 WHERE a.name = 'Tom Jones' AND m.title = 'Life is Wonderful'
-CREATE (a)-[rel:ACTED_IN]-(m)
-CREATE (a)-[rel:ACTED_IN {roles: ['The Villain']}]-(m)
-CREATE (a)-[rel:ACTED_IN {roles: ['The Villain','Joe']}]-(m)
+CREATE (a)-[rel:ACTED_IN]->(m)
+CREATE (a)-[rel:ACTED_IN {roles: ['The Villain']}]->(m)
+CREATE (a)-[rel:ACTED_IN {roles: ['The Villain','Joe']}]->(m)
 ----
 
 [.statement]

--- a/modules/4.0-intro-neo4j/docs/12_MergingData.adoc
+++ b/modules/4.0-intro-neo4j/docs/12_MergingData.adoc
@@ -23,7 +23,7 @@ At the end of this module, you should be able to write Cypher statements to:
 ** Creating nodes.
 ** Creating relationships.
 
-== Merging data in the graph
+== Creating data in the graph
 [.notes]
 --
 Thus far, you have learned how to create nodes, labels, properties, and relationships in the graph.
@@ -68,10 +68,6 @@ Node creation behaviors:
 *Relationship*: If the relationship exists, a duplicate relationship is created.
 endif::[]
 
-
-[NOTE]
-[.statement]
-You should never create duplicate nodes or relationships in a graph.
 
 == Using `MERGE`
 
@@ -437,6 +433,7 @@ What are your options to process this `MERGE` clause?
 ----
 MATCH (p {name: 'Jane Doe'}),(m:Movie {title:'The Good One'})
 MERGE (p)-[rel:ACTED_IN]->(m)
+SET rel.role=['role']
 ----
 
 [.statement]

--- a/modules/4.0-intro-neo4j/docs/14_UsingIndexes.adoc
+++ b/modules/4.0-intro-neo4j/docs/14_UsingIndexes.adoc
@@ -219,8 +219,7 @@ After creating a full-text schema index, you can always get of listing of all ex
 --
 [source,cypher]
 ----
-CALL db.index.fulltext.createNodeIndex(
-     'MovieTitlePersonName',['Movie', 'Person'], ['title', 'name'])
+CALL db.indexes()
 ----
 
 [.statement]

--- a/modules/4.0-intro-neo4j/docs/17_UsingLOADCSVForImport.adoc
+++ b/modules/4.0-intro-neo4j/docs/17_UsingLOADCSVForImport.adoc
@@ -53,7 +53,7 @@ Assuming that you have an agreed-upon data model, here are the basic steps you s
 . Determine how the CSV file will be structured.
 . Determine if normalized or denormalized data.
 . Ensure IDs to be used in the data are unique.
-. Ensure data in CSV files is "clean".]
+. Ensure data in CSV files is "clean".
 . Execute Cypher code to inspect the data.
 . Determine if data needs to be transformed.
 . Ensure constraints are created in the graph.
@@ -422,8 +422,9 @@ In this example, we import the movie data:
 
 [source,cypher]
 ----
+USING PERIODIC COMMIT 500
 LOAD CSV WITH HEADERS FROM
-  'https://data.neo4j.com/v4.0-intro-neo4j/movie1s.csv' as row
+  'https://data.neo4j.com/v4.0-intro-neo4j/movies1.csv' as row
 MERGE (m:Movie {id:toInteger(row.movieId)})
     ON CREATE SET
           m.title = row.title,
@@ -466,7 +467,7 @@ In this example, we import the data to create the relationships between existing
 [source.fit,cypher]
 ----
 LOAD CSV WITH HEADERS FROM
-https://data.neo4j.com/v4.0-intro-neo4j/directors.csv' AS row
+'https://data.neo4j.com/v4.0-intro-neo4j/directors.csv' AS row
 MATCH (movie:Movie {id:toInteger(row.movieId)})
 MATCH (person:Person {id: toInteger(row.personId)})
 MERGE (person)-[:DIRECTED]->(movie)

--- a/modules/4.0-intro-neo4j/docs/18_UsingAPOCForImport.adoc
+++ b/modules/4.0-intro-neo4j/docs/18_UsingAPOCForImport.adoc
@@ -451,7 +451,7 @@ Select the correct answers.
 - [ ] Scheduling when a load should occur.
 - [x] Executing Cypher code when a condition is true and alternate Cypher code when the condition is false.
 - [ ] An alternative to the `MERGE` clause.
-- [x] Profiling the execution of a query.
+- [ ] Profiling the execution of a query.
 
 === Question 3
 


### PR DESCRIPTION
05_Working with patterns in queries
Distinguish better two MATCH clauses and two patterns in a single MATCH clause
Remove extra ()

07_Controlling the query chain
Remove label :Movie when using size

08_Controlling results returned
Fix space typo
Follow the style guide and write anonymous nodes in a pattern last
Fix answers to question 3

10_CreatingRelationships
Fix answers to question 3- missing directions

12_Merging data
Fix confusing slide title
Remove note about never creating duplicate nodes or relations in the graph- not true in all cases
Question 3- attempted to fix it, wasn’t clear

14_usingIndexes
Fix listing indexes

17_UsingLoadCSV for import
Typo fix
Fix filename, and also add USING PERIODIC COMMIT (no example)

18_Using APOC
Fix answer to Question 2