### PR TITLE
Disable sso to prevent an additional call to /authorize

### DIFF
--- a/resources/templates/course/_quizzes.js
+++ b/resources/templates/course/_quizzes.js
@@ -229,7 +229,8 @@ document.addEventListener('DOMContentLoaded', function () {
           audience: 'neo4j://accountinfo/',
           params: {
             scope: 'read:account-info write:account-info openid email profile user_metadata'
-          }
+          },
+          sso: false
         }
       }
     )


### PR DESCRIPTION
Disabling `autoParseHash` had no effect but disabling the `sso` removed an extra call. Since we are explicitly calling `checkSession` I believe we can safely disable `sso`.
The following use case is working as expected:

1. logout using https://neo4j.com/accounts/logout 
1. go to https://neo4j.com/graphacademy/online-training/v4/_testing_00-intro-neo4j-about/ (you will be redirected to the login page)
1. login (you will be redirected to the course page
1. enjoy!

//cc @spgandhi

