### PR TITLE
Move S3 upload tasks after convert tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,55 +285,7 @@ subprojects {
           }
         }
       }
-    } else {
-      if (new File(sourceImagesDirPath).exists()) {
-        if (stage == 'production') {
-          task s3UploadImages(type: S3UploadTask) {
-            //overwrite = true
-            source = sourceImagesDirPath
-            bucket = "dev.assets.neo4j.com"
-            destination = "course/${project.name}/images"
-            acl.set(CannedAccessControlList.PublicRead)
-          }
-        } else if (stage == 'testing') {
-          task s3UploadImages(type: S3UploadTask) {
-            //overwrite = true
-            source = sourceImagesDirPath
-            bucket = "dev.assets.neo4j.com"
-            destination = "test-course/${project.name}/images"
-            acl.set(CannedAccessControlList.PublicRead)
-          }
-        }
-      }
-
-      if (stage == 'production' || stage == 'testing') {
-        task s3UploadSetup(type: S3UploadTask) {
-          dependsOn convertSetupHtml
-          source = "${projectDir}/build/setup"
-          bucket = "graphacademy.neo4j.com"
-          destination = "setup"
-          acl.set(CannedAccessControlList.PublicRead)
-        }
-        task wordPressUploadCourse(type: WordPressUploadTask) {
-          dependsOn convertOnlineHtml
-          source = convertOnlineHtml.outputs.files
-          type = "course"
-          status = stage == 'production' ? "publish" : "private"
-        }
-        task wordPressUploadEnrollment(type: WordPressUploadTask) {
-          dependsOn convertEnrollmentHtml
-          source = convertEnrollmentHtml.outputs.files
-          type = "page"
-          status = stage == 'production' ? "publish" : "private"
-          template = "page-inner-100-mkto.php"
-        }
-        task wordPressUpload {
-          dependsOn wordPressUploadCourse
-          dependsOn wordPressUploadEnrollment
-        }
-      }
     }
-
 
     task convertOnlineHtml(type: AsciidoctorTask) {
       dependsOn asciidoctorGemsPrepare, generateModuleDescriptor
@@ -674,6 +626,55 @@ subprojects {
 
     task liveReload(type: LiveReloadTask) {
       docRoot "${projectDir}/build"
+    }
+
+    if (!project.hasProperty("browserGuides")) {
+      if (new File(sourceImagesDirPath).exists()) {
+        if (stage == 'production') {
+          task s3UploadImages(type: S3UploadTask) {
+            //overwrite = true
+            source = sourceImagesDirPath
+            bucket = "dev.assets.neo4j.com"
+            destination = "course/${project.name}/images"
+            acl.set(CannedAccessControlList.PublicRead)
+          }
+        } else if (stage == 'testing') {
+          task s3UploadImages(type: S3UploadTask) {
+            //overwrite = true
+            source = sourceImagesDirPath
+            bucket = "dev.assets.neo4j.com"
+            destination = "test-course/${project.name}/images"
+            acl.set(CannedAccessControlList.PublicRead)
+          }
+        }
+      }
+
+      if (stage == 'production' || stage == 'testing') {
+        task s3UploadSetup(type: S3UploadTask) {
+          dependsOn convertSetupHtml
+          source = "${projectDir}/build/setup"
+          bucket = "graphacademy.neo4j.com"
+          destination = "setup"
+          acl.set(CannedAccessControlList.PublicRead)
+        }
+        task wordPressUploadCourse(type: WordPressUploadTask) {
+          dependsOn convertOnlineHtml
+          source = convertOnlineHtml.outputs.files
+          type = "course"
+          status = stage == 'production' ? "publish" : "private"
+        }
+        task wordPressUploadEnrollment(type: WordPressUploadTask) {
+          dependsOn convertEnrollmentHtml
+          source = convertEnrollmentHtml.outputs.files
+          type = "page"
+          status = stage == 'production' ? "publish" : "private"
+          template = "page-inner-100-mkto.php"
+        }
+        task wordPressUpload {
+          dependsOn wordPressUploadCourse
+          dependsOn wordPressUploadEnrollment
+        }
+      }
     }
 
     task s3Upload dependsOn(tasks.names.findAll { it.startsWith("s3Upload") && it != "s3Upload" })


### PR DESCRIPTION
Fix the issue found by Elaine while running:

```
$ gw training_HandsOnWithNeo4jGraphDataScienceLibrary:s3UploadSetup -Pstage=production -Ps3-region=us-east-2
```

The error was:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/path/to/build.gradle' line: 311

* What went wrong:
A problem occurred configuring project ':4.0-cypher-query-tuning'.
> Could not get unknown property 'convertSetupHtml' for task ':4.0-cypher-query-tuning:s3UploadSetup' of type com.neo4j.gradle.s3.S3UploadTask.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```