### PR TITLE
Update 02-querying40-using-where-to-filter-queries.adoc

### DIFF
--- a/modules/4.0-querying/modules/ROOT/pages/02-querying40-using-where-to-filter-queries.adoc
+++ b/modules/4.0-querying/modules/ROOT/pages/02-querying40-using-where-to-filter-queries.adoc
@@ -135,7 +135,7 @@ endif::[]
 [.statement]
 For example, these two Cypher queries:
 
-[[source,cypher,role=noplay]
+[source,cypher,role=noplay]
 ----
 MATCH (p:Person) 
 RETURN p.name


### PR DESCRIPTION
Fixed typo.  Extra open square bracket '['