### PR TITLE
Replace "relationship" with "hyperedge"

### DIFF
--- a/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
+++ b/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
@@ -47,7 +47,7 @@ image::IntermediateNodesBefore.png[IntermediateNodesBefore,width=600,align=cente
 --
 Here we have the _WORKED_AT_ hyperedge that has the from and to properties, but we need to associate the role with this period of work.
 In Neo4j, there is no way to create a relationship that connects a relationship to a node.
-Relationships can only connect nodes.
+Neo4j relationships can only connect nodes.
 --
 
 === Using intermediate nodes
@@ -56,11 +56,11 @@ image::IntermediateNodesAfter.png[IntermediateNodesAfter,width=600,align=center]
 
 [.notes]
 --
-The solution is to add a connection point in the middle of the relationship.
-Since nodes are connection points, you simply create a node in the middle of the relationship.
+The solution is to replace the hyperedge with a connection point node.
+Since nodes are connection points, you simply create a node in the middle of the hyperedge.
 
 In this example, we replace the _WORKED_AT_ hyperedge with an Employment intermediate node.
-This provides a connection point that allows us  connect any amount of information to Patrick’s term of employment at Acme.
+This provides a connection point that allows us connect any amount of information to Patrick’s term of employment at Acme.
 --
 
 === Intermediate nodes: sharing context
@@ -70,7 +70,7 @@ image::IntermediateNodesSharingContext.png[IntermediateNodesSharingContext,width
 [.notes]
 --
 This model allows different employment events to share contextual information.
-Person nodes can have a shared Role or Company, and allow us to very easily  trace either the full details of a single person’s career, or the overlap between different individuals.
+Person nodes can have a shared Role or Company, and allow us to very easily trace either the full details of a single person’s career, or the overlap between different individuals.
 --
 
 === Intermediate nodes: sharing data

--- a/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
+++ b/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
@@ -122,7 +122,13 @@ image::LinkedList1.png[LinkedList1,width=900,align=center]
 [.notes]
 --
 Linked lists are not unique to graphs.  They are a common pattern in lots of data modeling paradigms.
-In some of those paradigms, you see both the singly-linked list (above)  and the doubly-linked list (below).
+In some of those paradigms, you see both the singly-linked list (above) and the doubly-linked list (below).
+
+However, singly-linked lists in Computer Science are one-way: they have a destination but no soure information.
+Neo4J relationships tracks both from and to node, so they are different from Computer Science singly-linked lists.
+
+The power of a Graph Database is that the To-From relationship is maintained in the database,
+whereas in a Traditional Relational Database a row with a Primary Key has no information about who is pointing to it.
 
 ifndef::env-slides[]
 You should *never* use a doubly-linked list in Neo4j because doubly-linked lists use redundant symmetrical relationships.

--- a/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
+++ b/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
@@ -45,7 +45,7 @@ image::IntermediateNodesBefore.png[IntermediateNodesBefore,width=600,align=cente
 
 [.notes]
 --
-Here we have the _WORKED_AT_ relationship that has the from and to properties, but we need to associate the role with this period of work.
+Here we have the _WORKED_AT_ hyperedge that has the from and to properties, but we need to associate the role with this period of work.
 In Neo4j, there is no way to create a relationship that connects a relationship to a node.
 Relationships can only connect nodes.
 --
@@ -59,7 +59,7 @@ image::IntermediateNodesAfter.png[IntermediateNodesAfter,width=600,align=center]
 The solution is to add a connection point in the middle of the relationship.
 Since nodes are connection points, you simply create a node in the middle of the relationship.
 
-In this example, we replace the _WORKED_AT_ relationship with an Employment intermediate node.
+In this example, we replace the _WORKED_AT_ hyperedge with an Employment intermediate node.
 This provides a connection point that allows us  connect any amount of information to Patrick’s term of employment at Acme.
 --
 


### PR DESCRIPTION
It's confusing to the newbie to see the word "relationship" to refer to a thing that cannot be created in Neo4J but is different from Neo4J relationships.

I'd prefer it if it was clear that what is being replaced (hyperedge) was different from what's in the Neo4J world.