### PR TITLE
Update 01-querying40-introduction-to-cypher.adoc

### DIFF
--- a/modules/4.0-querying/modules/ROOT/pages/01-querying40-introduction-to-cypher.adoc
+++ b/modules/4.0-querying/modules/ROOT/pages/01-querying40-introduction-to-cypher.adoc
@@ -1541,7 +1541,7 @@ endif::[]
 == Querying by multiple relationships
 
 ifndef::env-slides[]
-Here is another example where we want to know the movies that _Tom Hanks_ acted in and directed:
+Here is another example where we want to know the movies that _Tom Hanks_ acted in or directed:
 endif::[]
 
 


### PR DESCRIPTION
It was:

> Here is another example where we want to know the movies that _Tom Hanks_ acted in and directed:

When I read it first, my impression was that both relationships (ACTED_IN and DIRECTED) must exist for the movie to be returned while only one needs to exist.

Therefore I propose replacing `and` with `or`:

> Here is another example where we want to know the movies that _Tom Hanks_ acted in or directed: