### PR TITLE
Update 02-overview40-neo4j-graph-platform.adoc

### DIFF
--- a/modules/4.0-overview/modules/ROOT/pages/02-overview40-neo4j-graph-platform.adoc
+++ b/modules/4.0-overview/modules/ROOT/pages/02-overview40-neo4j-graph-platform.adoc
@@ -478,7 +478,7 @@ endif::[]
 == Neo4j Sandbox
 
 ifndef::env-slides[]
-The Neo4j Sandbox is way that you can begin development with Neo4j.
+The Neo4j Sandbox is the way that you can begin development with Neo4j.
 It is a free, temporary, and cloud-based instance of a Neo4j Server with its associated graph that you can access from any Web browser. The database in a Sandbox may be empty or it may be pre-populated. It is started automatically for you when you create the Sandbox.
 endif::[]
 


### PR DESCRIPTION
Fixing small typo on lesson. Closes #260. 

I've suggested 'the', but 'a' can also be used instead.

