### PR TITLE
Typo in Varying length patterns - 2 section

### DIFF
--- a/modules/4.0-querying/modules/ROOT/pages/03-querying40-working-with-patterns-in-queries.adoc
+++ b/modules/4.0-querying/modules/ROOT/pages/03-querying40-working-with-patterns-in-queries.adoc
@@ -367,7 +367,7 @@ Retrieve the paths of length 3 with the relationship, _:RELTYPE_ from _nodeA_ to
 
 [source,syntax,role=nocopy noplay]
 ----
-(node1)-[:RELTYPE*3]->(node2)
+(nodeA)-[:RELTYPE*3]->(nodeB)
 ----
 
 [.statement]
@@ -375,7 +375,7 @@ Retrieve the paths of lengths 1, 2, or 3 with the relationship, _:RELTYPE_ from 
 
 [source,syntax,role=nocopy noplay]
 ----
-(node1)-[:RELTYPE*1..3]->(node2)
+(nodeA)-[:RELTYPE*1..3]->(nodeB)
 ----
 
 == Finding the shortest path


### PR DESCRIPTION
In the section [Varying length patterns](https://neo4j.com/graphacademy/training-querying-40/03-querying40-working-with-patterns-in-queries/#_syntax_varying_length_patterns_2) the explanation mentions nodeA, nodeB, etc... For example:

>Retrieve the paths of length 3 with the relationship, _:RELTYPE_ from _nodeA_ to _nodeB_:

But the example statement uses node1 and node2.

>(node1)-[:RELTYPE*1..3]->(node2)

This isn't a massive source of confusion and can be easily corrected to match the example statements in the previous section