### PR TITLE
Spelling mistake corrected

### DIFF
--- a/modules/4.0-querying/modules/ROOT/pages/05-querying40-controlling-query-chain.adoc
+++ b/modules/4.0-querying/modules/ROOT/pages/05-querying40-controlling-query-chain.adoc
@@ -47,7 +47,7 @@ image::WithoutWITH.png[WithoutWITH,width=800,align=center]
 --
 What if we wanted to further qualify the query so that we only return the actors who have made 2 or 3 movies?
 What we really want to do is test the count of each movie, but the count is an aggregating function so we cannot test it until all nodes have been retrieved.
-One way to to this is with the `WITH` clause in Cypher.
+One way to do this is with the `WITH` clause in Cypher.
 --
 
 === Example: Using `WITH`


### PR DESCRIPTION
Updated 05-querying40-controlling-query-chain.adoc

Spelling mistake found during reading the documentation. Corrected from 'to' to 'do', under "Intermediate processing using WITH" section.
Thank you.