### PR TITLE
error in syntax

### DIFF
--- a/modules/4.0-neo4j-admin/modules/ROOT/pages/04-using-cypher-shell-manage-databases.adoc
+++ b/modules/4.0-neo4j-admin/modules/ROOT/pages/04-using-cypher-shell-manage-databases.adoc
@@ -304,7 +304,7 @@ Another way that you can do is is to use the following command:
 
 [source,syntax,role= nocopy noplay]
 ----
-CREATE OR REPLACE <database>;
+CREATE OR REPLACE DATABASE <database>;
 ----
 
 == Conditionally creating a database
@@ -316,7 +316,7 @@ If you are scripting the creation of databases, you can also create a database i
 
 [source,syntax,role= nocopy noplay]
 ----
-CREATE <database> IF NOT EXISTS;
+CREATE DATABASE <database> IF NOT EXISTS;
 ----
 
 [NOTE]


### PR DESCRIPTION
We are missing the DATABASE command in these two examples.

`CREATE OR REPLACE <database>;`

`CREATE <database> IF NOT EXISTS;`

If you run the example cypher queries you will receive the following errors:

```
neo4j@system> CREATE OR REPLACE testing;

Invalid input 't': expected whitespace, comment, DATABASE, ROLE, USER, CONSTRAINT, LOOKUP, FULLTEXT, BTREE or INDEX (line 2, column 19 (offset: 19))
"CREATE OR REPLACE testing;"
                   ^
```

```
neo4j@system> CREATE testing IF NOT EXISTS;

Invalid input 'I': expected whitespace, comment, '=', node labels, MapLiteral, a parameter, a parameter (old syntax), a relationship pattern, ',', USE GRAPH, LOAD CSV, START, MATCH, UNWIND, MERGE, CREATE UNIQUE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, CALL, RETURN, UNION, ';' or end of input (line 2, column 20 (offset: 20))
"CREATE databaseone IF NOT EXISTS;"
                    ^
```