### PR TITLE
Fix SyntaxError

### DIFF
--- a/browser-guides/4.0-query-tuning-exercises/docs/scripts/AfterExercise4.cypher
+++ b/browser-guides/4.0-query-tuning-exercises/docs/scripts/AfterExercise4.cypher
@@ -42,7 +42,7 @@ UNWIND m.genres as name
 WITH DISTINCT name, m
 MERGE (g:Genre {name:name})
 WITH g, m
-MERGE (g)<-[:IS_GENRE]-(m)
+MERGE (g)<-[:IS_GENRE]-(m);
 
 CALL db.index.fulltext.createNodeIndex(
 'MovieTitleMixedCase',['Movie'], ['title'])


### PR DESCRIPTION
Fix a typo in the setup script of course 4 exercise 5 (called "Reducing Cardinality with LIMIT, DISTINCT (Preparations)"), the ';' character is required in order to avoid a SyntaxError.