### PR TITLE
Relation :ENDED shouldn't be between User and Month nodes

### DIFF
--- a/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
+++ b/modules/graph-data-modeling/modules/ROOT/pages/04-common-graph-structures.adoc
@@ -259,6 +259,7 @@ Employment events themselves are intermediate nodes connecting people, companies
 In this case, the intermediate nodes are serving the dual purposes of reducing the density of Person nodes, and providing an attachment point for the timeline tree.
 --
 
+
 image::PartialIntermediateNodes.png[PartialIntermediateNodes,width=900,align=center]
 
 === Using linked list


### PR DESCRIPTION
There is one mismatch in diagram `PartialIntermediateNodes.png`
The link between Person (name: 'David') and Month (value: 7) should be probably replaced with relation between Employment (from: 2001, to: 2005) and Month (value: 3) same as other :ENDED relations are defined i.e. between Employment and Month nodes.
Pls do not merge this PR - it's just indication that image should be regenerated. 
