### PR TITLE
Update 03-cqt-40-reducing-cardinality.adoc

### DIFF
--- a/modules/4.0-cypher-query-tuning/modules/ROOT/pages/03-cqt-40-reducing-cardinality.adoc
+++ b/modules/4.0-cypher-query-tuning/modules/ROOT/pages/03-cqt-40-reducing-cardinality.adoc
@@ -361,7 +361,7 @@ You never want to see _AllNodesScan_ in an execution plan.
 
 [.notes]
 --
-You want to see NodeByLabelScan in your execution plans if an index will cannot be used.
+You want to see NodeByLabelScan in your execution plans if an index cannot be used.
 You must be familiar with how labels are used.
 Ideally you want the greatest selectivity for the anchor nodes.
 


### PR DESCRIPTION
Minor typo correction - removed extra `will` - from `...if an index will cannot be used.` to `if an index cannot be used.`