### PR TITLE
Property existence check per 4.3+ standards

### DIFF
--- a/modules/4.0-best-practices/modules/ROOT/pages/01-best-practices40-defining-constraints-data.adoc
+++ b/modules/4.0-best-practices/modules/ROOT/pages/01-best-practices40-defining-constraints-data.adoc
@@ -315,7 +315,7 @@ If we set these properties for all nodes in the graph that do not have _born_ pr
 [source,Cypher,role=nocopy noplay]
 ----
 MATCH (p:Person) 
-WHERE NOT exists(p.born)
+WHERE p.born IS NULL
 SET p.born = 0
 ----
 


### PR DESCRIPTION
Per the latest [Cypher Manual](https://neo4j.com/docs/cypher-manual/current/clauses/where/#property-existence-checking), 

_The exists() function has been deprecated for property existence checking and has been superseded by IS NOT NULL._

So I've changed 
_WHERE NOT exists(p.born)_
to
_WHERE p.born IS NULL_